### PR TITLE
make app license unambiguous

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,3 +18,16 @@ Teaser Video
 <img src="http://img.youtube.com/vi/VHZ9dA5ELXE/0.jpg" 
 alt="Oversec Teaser" width="240" height="180" border="10" />
 </a>
+
+
+## LICENSE
+
+```
+Copyright (C) <year> <name of author>
+
+This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
+```


### PR DESCRIPTION
* this makes license unambiguous
* github/gitlab license templates does not distinguish between only or later versions. ex, version 3 only OR version 3 or later.
* feel free to outright reject or accept as it is, however, make time to explicitly declare or educate your choosen license without any ambiguity for your code !
* License: GPL-3.0-or-later https://gitlab.com/fdroid/fdroiddata/-/blob/master/metadata/io.oversec.one.yml
* inspiration: 
  * For Clarity's Sake, Please Don't Say "Licensed under GNU GPL 2"! by Richard Stallman https://www.gnu.org/licenses/identify-licenses-clearly.html
  * REUSE makes software licensing as easy as one-two-three https://fsfe.org/news/2024/news-20241114-01.en.html